### PR TITLE
Fix 0-degree intersection size for `intersections='all'` mode

### DIFF
--- a/R/data.R
+++ b/R/data.R
@@ -575,29 +575,32 @@ upset_data = function(
     exclusive_intersection = as.numeric(exclusive_intersection)
     names(exclusive_intersection) = observed_intersections
 
+    product_matrix[product_matrix == 0] = -1
 
     if (NOT_IN_KNOWN_SETS %in% rownames(product_matrix) && NOT_IN_KNOWN_SETS %in% colnames(product_matrix)) {
-        product_matrix[NOT_IN_KNOWN_SETS, NOT_IN_KNOWN_SETS] = 1
+        product_matrix[NOT_IN_KNOWN_SETS, ] = -1
+        product_matrix[, NOT_IN_KNOWN_SETS] = -1
+        product_matrix[NOT_IN_KNOWN_SETS, NOT_IN_KNOWN_SETS] = 0
     }
 
     exclusive_intersection_counts = exclusive_intersection[colnames(product_matrix)]
-    inclusive_union = (product_matrix != 0) * exclusive_intersection_counts
+    inclusive_union = (product_matrix >= 0) * exclusive_intersection_counts
 
     observed_intersections_degrees = colSums(unique_members_matrix)
     desired_intersections_degrees = rowSums(intersections_matrix)
 
-    exclusive_union = ((product_matrix != 0) & (product_matrix >= observed_intersections_degrees)) * exclusive_intersection_counts
+    exclusive_union = ((product_matrix >= 0) & (product_matrix >= observed_intersections_degrees)) * exclusive_intersection_counts
 
     if (NOT_IN_KNOWN_SETS %in% colnames(product_matrix)) {
-        desired_intersections_degrees[NOT_IN_KNOWN_SETS] = 1
+        desired_intersections_degrees[NOT_IN_KNOWN_SETS] = 0
     }
 
     intersection_condition = t(t(product_matrix) >= desired_intersections_degrees)
     inclusive_intersection = intersection_condition * exclusive_intersection_counts
 
     if (!specific_intersections && intersections != 'observed') {
-        exclusive_intersection = t(t(product_matrix) == observed_intersections_degrees) & (product_matrix == observed_intersections_degrees)
-        exclusive_intersection = exclusive_intersection * exclusive_intersection_counts
+        exclusive_condition = t(t(product_matrix) == observed_intersections_degrees) & (product_matrix == observed_intersections_degrees)
+        exclusive_intersection = exclusive_condition * exclusive_intersection_counts
         exclusive_intersection[is.na(exclusive_intersection)] = 0
         exclusive_intersection = colSums(exclusive_intersection)
     }

--- a/tests/testthat/test-data.R
+++ b/tests/testthat/test-data.R
@@ -284,6 +284,26 @@ test_that("counts are properly computed in all modes", {
     )
 })
 
+
+test_that("zero degree intersection size is computed properly", {
+    df = data.frame(
+        a=c(FALSE, TRUE, FALSE, FALSE),
+        b=c(FALSE, FALSE, FALSE, FALSE),
+        c=c(TRUE, FALSE, FALSE, FALSE)
+    )
+    sizes = upset_data(
+        df,
+        c('a', 'b', 'c'),
+        intersections='all'
+    )$sizes
+
+    modes = c('exclusive_intersection', 'inclusive_intersection', 'exclusive_union', 'inclusive_union')
+    for (mode in modes) {
+        expect_equal(sizes[[mode]][[NOT_IN_KNOWN_SETS]], 2)
+    }
+})
+
+
 test_that("upset_data() filters by min_size, max_size, min_degree and max_degree", {
     # intersection: size, degree
     # a:     1, 1


### PR DESCRIPTION
Fixes #139

Makes zero-degree intersection size for `intersections='all'` mode follow the same behaviour as the barplot.

Before:

![image](https://user-images.githubusercontent.com/5832902/144940678-21b4a766-bc5e-4575-9047-5a02d1cf0a2e.png)

After:

![image](https://user-images.githubusercontent.com/5832902/144940713-56fd82b5-d502-4780-bcc6-384c08b6d544.png)

Repro:

```R
upset(
    data.frame(
        a=c(FALSE, TRUE, FALSE, FALSE),
        b=c(FALSE, FALSE, FALSE, FALSE),
        c=c(TRUE, FALSE, FALSE, FALSE)
    ),
    c('a', 'b', 'c'),
    sort_intersections_by='degree',
    intersections='all'
)
```