### PR TITLE
Fix issue #206 - User labels now respected

### DIFF
--- a/R/upset.R
+++ b/R/upset.R
@@ -1084,8 +1084,12 @@ upset = function(
       user_y_scale = scale_y_discrete()
   } else {
       user_y_scale = user_y_scale[[1]]
-      user_y_scale$limits = y_scale$limits
-      user_y_scale$labels = y_scale$labels
+      if (is.null(user_y_scale$limits)) {
+          user_y_scale$limits = y_scale$limits
+      }
+      if (length(user_y_scale$labels) == 0) {
+          user_y_scale$labels = y_scale$labels
+      }
       y_scale = NULL
   }
 


### PR DESCRIPTION
This fixes #206.

If the user specifies `scale_y_discrete` labels or limits, `upset` will not overwrite them (passing eventual errors to the incautious user).