### PR TITLE
Dynamic registration of themes

### DIFF
--- a/R/upset.R
+++ b/R/upset.R
@@ -18,42 +18,49 @@ globalVariables(c(
 #'
 #' @export
 #' @importFrom ggplot2 theme_minimal element_blank
-upset_themes = list(
-  intersections_matrix=list(
-    theme_minimal(),
-    theme(
-      # hide intersections
-      axis.text.x=element_blank(),
-      axis.ticks.x=element_blank(),
-      # hide group title
-      axis.title.y=element_blank()
-    )
-  ),
-  'Intersection size'=list(
-    theme_minimal(),
-    theme(
-      axis.text.x=element_blank(),
-      axis.title.x=element_blank()
-    )
-  ),
-  overall_sizes=list(
-    theme_minimal(),
-    theme(
-      # hide groups
-      axis.title.y=element_blank(),
-      axis.text.y=element_blank(),
-      axis.ticks.y=element_blank()
-    )
-  ),
-  default=list(
-    theme_minimal(),
-    theme(
-      axis.text.x=element_blank(),
-      axis.title.x=element_blank()
+upset_themes <- NULL
+
+.onLoad <- function(lib, pkg) {
+  upset_themes <<- new_upset_themes()
+}
+
+new_upset_themes <- function() {
+  list(
+    intersections_matrix=list(
+      theme_minimal(),
+      theme(
+        # hide intersections
+        axis.text.x=element_blank(),
+        axis.ticks.x=element_blank(),
+        # hide group title
+        axis.title.y=element_blank()
+      )
+    ),
+    'Intersection size'=list(
+      theme_minimal(),
+      theme(
+        axis.text.x=element_blank(),
+        axis.title.x=element_blank()
+      )
+    ),
+    overall_sizes=list(
+      theme_minimal(),
+      theme(
+        # hide groups
+        axis.title.y=element_blank(),
+        axis.text.y=element_blank(),
+        axis.ticks.y=element_blank()
+      )
+    ),
+    default=list(
+      theme_minimal(),
+      theme(
+        axis.text.x=element_blank(),
+        axis.title.x=element_blank()
+      )
     )
   )
-)
-
+}
 
 #' Default themes modified by specified arguments
 #'


### PR DESCRIPTION
Hi there,

We've been preparing a new major release for ggplot2 and found an issue during a reverse dependency check of shared reverse dependencies. We then traced back the issue to ComplexUpset.

In essence what happened was that ComplexUpset gets build on CRAN's machines with a fixed `upset_themes` list. If ggplot2 then changes an internal about how themes work, the fixed theme list does not reflect the updates. The remedy for this would be to register the `upset_themes` list when the ComplexUpset package is loaded (instead of when it is build). This PR dynamically sets the themes, which would resolve the issue in our shared reverse dependencies.

Please note that I wasn't able to execute the `test-examples.R` file, and you may have to inspect the unit tests manually. Some changes in visual tests are expected, primary due to absent axis ticks no longer taking up space.

You can test your code with the development version of ggplot2 by installing it as follows:

```r
# install.packages("pak")
pak::pak("tidyverse/ggplot2")
```

We aim to release the new ggplot2 version in about 2 weeks, and hope you can submit a fix to CRAN around that time. Hopefully this will inform you in a timely manner.

Best wishes,
Teun